### PR TITLE
Semver and action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get update && \
     apt-get install -y msmtp ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+RUN docker-php-ext-install pdo_mysql
+
 # Create msmtp config template
 COPY msmtp_entrypoint.sh /usr/local/bin/msmtp_entrypoint.sh
 RUN chmod +x /usr/local/bin/msmtp_entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM wordpress:6.8.1-apache
 
 # Install msmtp, ca-certificates and PHP MySQL extension
 RUN apt-get update && \
-    apt-get install -y msmtp ca-certificates php-mysql && \
+    apt-get install -y msmtp ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # Create msmtp config template


### PR DESCRIPTION
This pull request makes a small adjustment to the `Dockerfile` for the WordPress image. The change removes the installation of the `php-mysql` package, leaving only `msmtp` and `ca-certificates` to be installed.